### PR TITLE
Made it so packt.sh can be ran from any directory.

### DIFF
--- a/packt.sh
+++ b/packt.sh
@@ -2,7 +2,9 @@
 
 # Packt daily free e-book claim & download
 
-source "packt.cfg"
+CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CONFIG_DIR/packt.cfg"
 
 function log {
     echo "$(date '+%Y-%m-%d %H:%M:%S ') $1" >> "$log"


### PR DESCRIPTION
Adding BASH_SOURCE to get the directory of the calling script

Issue 3 requested the have the base directory be a variable to allow the script to be called by the full path instead of having to be in the directory when running the script.